### PR TITLE
compose: update to v5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,7 @@ jobs:
       - run:
           name: Install Docker Compose
           environment:
-            COMPOSE_VERSION: 'v2.25.0'
+            COMPOSE_VERSION: 'v5.0.2'
           command: |
             curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/docker-compose
             mkdir -p ~/.docker/cli-plugins

--- a/Tiltfile
+++ b/Tiltfile
@@ -1,9 +1,5 @@
 # -*- mode: Python -*-
 
-# Enforce a minimum Tilt version, so labels are supported
-# https://docs.tilt.dev/api.html#api.version_settings
-version_settings(constraint='>=0.22.1')
-
 docker_compose('docker-compose.yml')
 
 docker_build(
@@ -23,5 +19,5 @@ docker_build(
   ])
 
 # Add labels to Docker services
-dc_resource('redis', labels=["database"])
+dc_resource('cache', labels=["database"])
 dc_resource('app', labels=["server"])

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,20 +1,15 @@
-version: "3.9"
 services:
-  redis:
+  cache:
     image: redis
-    container_name: cache
     expose:
       - 6379
   app:
     image: tilt.dev/express-redis-app
-    links:
-      - redis
+    depends_on:
+      - cache
     ports:
       - 3000:3000
     environment:
       - REDIS_URL=redis://cache
       - NODE_ENV=development
       - PORT=3000
-    command:
-      sh -c 'node server.js'
-


### PR DESCRIPTION
- remove deprecated 'links' field
- remove deprecated 'version' field

Signed-off-by: Nick Santos <nicholas.j.santos@gmail.com>
